### PR TITLE
Treat headers with colspans as multiple ths

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -1,0 +1,65 @@
+<html>
+    <head>
+        <title>Tsorter demo</title>
+        <meta charset="UTF-8"> 
+        <script src="../src/tsorter.js"></script>
+    </head>
+
+    <style>
+        th { border: solid; border-width: 1px; }
+    </style>
+<body>
+
+<table id="silly_table">
+    <thead>
+        <tr>
+            <th colspan=2>Letter</th>
+            <th data-tsorter="numeric">Number</th>
+        </tr>
+    </th>
+
+    <tbody>
+    <tr>
+        <td>A</td>
+        <td>Aa</td>
+        <td>1</td>
+    </tr>
+    <tr>
+        <td>B</td>
+        <td>Bb</td>
+        <td>3</td>
+    </tr>
+
+    <tr>
+        <td>C</td>
+        <td>Cc</td>
+        <td>2</td>
+     </tr>
+     <tr>
+        <td>D</td>
+        <td>Dd</td>
+        <td>4</td>
+    </tr>
+      <tr>
+        <td>E</td>
+        <td>Ee</td>
+        <td>6</td>
+    </tr>
+       <tr>
+        <td>F</td>
+        <td>Ff</td>
+        <td>1</td>
+    </tr>
+   </tbody>
+</table>
+
+<script>
+function init() {
+    var sorter2 = tsorter.create('silly_table');
+}
+    
+window.onload = init;
+</script>
+
+</body>
+</html>

--- a/src/tsorter.js
+++ b/src/tsorter.js
@@ -63,7 +63,10 @@ var tsorter = (function()
             //  IE6,7,8 don't have it.
 
             // set the data retrieval function for this column 
-            that.column = th.cellIndex;
+            that.column = that.getHeaderIndex( that.table, th );
+
+            console.log("Sorting by column number " + that.column);
+
             that.get = that.getAccessor( th.getAttribute('data-tsorter') );
 
             if( that.prevCol === that.column )
@@ -204,6 +207,18 @@ var tsorter = (function()
             }
         },
 
+        getHeaderIndex: function( table, th ){
+            var ths = table.getElementsByTagName("th");
+            var index = 0;
+            for( var i = 0 ; i < ths.length ; i++ ){
+                var headerCell = ths[i];
+                if( headerCell.innerHTML === th.innerHTML ){
+                    return index;
+                }
+                index += headerCell.colSpan;
+            }
+        },
+
         readHeaders: function( table ){
             var ths = table.getElementsByTagName("th");
             var headers = [];
@@ -213,6 +228,7 @@ var tsorter = (function()
                 for( var j = 0; j<th.colSpan; j++ ){
                     headers[index] = th;
                     index++;
+                    console.log("Adding a header at index " + index + " for header " + th.innerHTML);
                 }
             }
             return headers;

--- a/src/tsorter.js
+++ b/src/tsorter.js
@@ -1,3 +1,8 @@
+/*!
+ * tsorter 2.0.0 - Copyright 2015 Terrill Dent, http://terrill.ca
+ * JavaScript HTML Table Sorter
+ * Released under MIT license, http://terrill.ca/sorting/tsorter/LICENSE
+ */
 var tsorter = (function()
 {
     'use strict';
@@ -64,13 +69,13 @@ var tsorter = (function()
             if( that.prevCol === that.column )
             {
                 // if already sorted, reverse
-                th.className = th.className !== 'descend' ? 'descend' : 'ascend';
+                th.className = th.className !== 'ascend' ? 'ascend' : 'descend';
                 that.reverseTable();
             }
             else
             {
                 // not sorted - call quicksort
-                th.className = 'descend';
+                th.className = 'ascend';
                 if( that.prevCol !== -1 && that.ths[that.prevCol].className !== 'exc_cell'){
                     that.ths[that.prevCol].className = '';
                 }
@@ -104,17 +109,16 @@ var tsorter = (function()
                     };
                 case "numeric":
                     return function(row){  
-                        return parseFloat( that.getCell(row).firstChild.nodeValue.replace(/\D/g,''), 10 );
+                        return parseFloat( that.getCell(row).firstChild.nodeValue, 10 );
                     };
                 default: /* Plain Text */
                     return function(row){  
-                        return that.getCell(row).firstChild.nodeValue.toLowerCase();
+                        return that.getCell(row).firstChild.nodeValue;
                     };
             }
         },
 
-        /* 
-         * Exchange
+        /* Exchange
          * A complicated way of exchanging two rows in a table.
          * Exchanges rows at index i and j
          */
@@ -200,6 +204,20 @@ var tsorter = (function()
             }
         },
 
+        readHeaders: function( table ){
+            var ths = table.getElementsByTagName("th");
+            var headers = [];
+            var index = 0;
+            for( var i = 0; i < ths.length; i++ ){
+                var th = ths[i];
+                for( var j = 0; j<th.colSpan; j++ ){
+                    headers[index] = th;
+                    index++;
+                }
+            }
+            return headers;
+        },
+
         init: function( table, initialSortedColumn, customDataAccessors ){
             var that = this,
                 i;
@@ -209,7 +227,7 @@ var tsorter = (function()
             }
 
             that.table = table;
-            that.ths   = table.getElementsByTagName("th");
+            that.ths   = that.readHeaders(table);
             that.tbody = table.tBodies[0];
             that.trs   = that.tbody.getElementsByTagName("tr");
             that.prevCol = ( initialSortedColumn && initialSortedColumn > 0 ) ? initialSortedColumn : -1;


### PR DESCRIPTION
I am not sure if you are interested in this, but I forked your code to support a use case of mine. I have a header which spans multiple columns, and I want to sort by the first column of that span, and then have subsequent columns sort according to their headers.

This is quite a simple change, but perhaps not something you want. It's obviously up to you. It's a bit of a corner case.

I guess the diff blew up because I work under unix, and so the line endings all changed. Really, the patch is small.

Anyway, take it if you want it.

I like your library, by the way. Not as heavyweight as jQuery.