### PR TITLE
Removed erroneous exchange on a list of three items

### DIFF
--- a/src/tsorter.js
+++ b/src/tsorter.js
@@ -164,13 +164,6 @@ var tsorter = (function()
                 that = this;
 
             if( hi <= lo+1 ){ return; }
-             
-            if( (hi - lo) === 2 ) {
-                if(that.get(hi-1) > that.get(lo)) {
-                    that.exchange(hi-1, lo);   
-                }
-                return;
-            }
             
             i = lo + 1;
             j = hi - 1;


### PR DESCRIPTION
The shortcut for a sort on a list of three items is erroneous as it wouldn't correctly sort a list like `[3, 1, 2]`.